### PR TITLE
Don't mkdirp in process.cwd()

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -166,10 +166,11 @@ Filter.prototype.processFile =
   return Promise.resolve(this.processString(contents, relativePath)).
       then(function asyncOutputFilteredFile(outputString) {
         var outputPath = internalGetDestFilePath(self, relativePath);
+        outputPath = destDir + '/' + outputPath;
         mkdirp.sync(path.dirname(outputPath));
-        fs.writeFileSync(
-            destDir + '/' + outputPath, outputString,
-            { encoding: outputEncoding });
+        fs.writeFileSync(outputPath, outputString, {
+          encoding: outputEncoding
+        });
       });
 };
 


### PR DESCRIPTION
Prior to this commit line 169 was doing a mkdirp in the current working directly. This commit ensures that the directory structure is written into the outputPath and not the current working directory.

I discovered this after I migrated the broccoli-babel-transpiler to use for stable path awesomeness.
