### PR TITLE
Use new broccoli-plugin base class

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var Promise = require('rsvp').Promise;
+var Plugin = require('broccoli-plugin');
 var helpers = require('broccoli-kitchen-sink-helpers');
 var walkSync = require('walk-sync');
 var mapSeries = require('promise-map-series');
@@ -14,12 +15,14 @@ var Cache = require('./cache');
 
 module.exports = Filter;
 
+Filter.prototype = Object.create(Plugin.prototype);
+Filter.prototype.constructor = Filter;
 function Filter(inputTree, options) {
   if (!this || !(this instanceof Filter) ||
       Object.getPrototypeOf(this) === Filter.prototype) {
     throw new TypeError('Filter is an abstract class and must be sub-classed');
   }
-  this.inputTree = inputTree;
+  Plugin.call(this, [inputTree]);
 
   /* Destructuring assignment in node 0.12.2 would be really handy for this! */
   if (options) {
@@ -38,9 +41,9 @@ function Filter(inputTree, options) {
   this._destFilePathCache = Object.create(null);
 }
 
-Filter.prototype.rebuild = function() {
+Filter.prototype.build = function build() {
   var self = this;
-  var srcDir = this.inputPath;
+  var srcDir = this.inputPaths[0];
   var destDir = this.outputPath;
   var paths = walkSync(srcDir);
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/caitp/cauliflower-filter#readme",
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.7",
+    "broccoli-plugin": "^1.0.0",
     "copy-dereference": "^1.0.0",
     "mkdirp": "^0.5.1",
     "promise-map-series": "^0.2.1",


### PR DESCRIPTION
This seems to work, with two caveats:

broccoli-babel-transpiler needs to be [updated to use `build`](https://gist.github.com/joliss/8c15a4e2825071c039b7)

Also, the test suite breaks completely, because mock-fs mocks out `fs`, while `broccoli-plugin` needs to use `require` and also do some symlinking work. My approach would be to rewrite the test suite to use (real) fixture trees instead - that way we'd avoid having to mock out global objects like `fs`. ([broccoli-fixturify](https://github.com/rwjblue/broccoli-fixturify) almost does what we need, but doesn't support setting mtimes. This could easily be added, either to broccoli-fixturify or as a new package.)

Before I spend half my afternoon rewriting the test suite, I thought I'd just send this patch and get your thoughts.
