### PR TITLE
Add key-for-file.js to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *
 !filter.js
 !cache.js
+!key-for-file.js
 !LICENSE


### PR DESCRIPTION
Getting this error with v1.2.0:

```
Cannot find module './key-for-file'
```

Also, see https://registry.npmjs.org/cauliflower-filter/-/cauliflower-filter-1.2.0.tgz.

I believe its just the .npmignore configuration. Might want to consider using a /lib folder instead.
